### PR TITLE
Add Game pid funs and List.seek

### DIFF
--- a/List.seek.fmc
+++ b/List.seek.fmc
@@ -1,0 +1,10 @@
+//Seeks the first occurrence that satisfies a condition
+List.seek: <A: Type> -> (A -> Bool) -> List(A) -> Maybe(A)
+  <A> (cond) (xs)
+  xs<() Maybe(A)>
+  | Maybe.none<A>;
+  | (head) (tail)
+    cond(head)<() Maybe(A)>
+    | Maybe.some<A>(head);
+    | List.seek<A>(cond)(tail);;
+

--- a/TaelinArena.Game.get_position_by_pid.fmc
+++ b/TaelinArena.Game.get_position_by_pid.fmc
@@ -1,0 +1,16 @@
+// Gets the position of an object by its id
+TaelinArena.Game.get_position_by_pid:
+  TaelinArena.Game.PlayerId ->
+  TaelinArena.Game.Game     -> 
+  F64.V3 
+
+  (pid) (gm) 
+  TaelinArena.Game.get_thing_by_pid(pid)(gm)<() F64.V3>
+  | F64.V3.new(F64.0)(F64.0)(F64.0);
+  | (found)
+    TaelinArena.Game.get_thing_pos(found);
+
+// get_position_by_pid(pid: PlayerId, gs: Game) : V3
+//   case get_thing_by_pid(pid, gs) as found
+//   | none => v3(0,0,0)
+//   | some => case found.value |thing found.value.pos

--- a/TaelinArena.Game.get_thing_by_pid.cond.fmc
+++ b/TaelinArena.Game.get_thing_by_pid.cond.fmc
@@ -1,0 +1,9 @@
+TaelinArena.Game.get_thing_by_pid.cond:
+  TaelinArena.Game.PlayerId ->
+  TaelinArena.Game.Thing ->
+  Bool
+
+  (pid) (thi)
+  let thi.pid = TaelinArena.Game.get_thing_pid(thi)
+  F64.eql(pid)(thi.pid)
+  

--- a/TaelinArena.Game.get_thing_by_pid.fmc
+++ b/TaelinArena.Game.get_thing_by_pid.fmc
@@ -1,0 +1,10 @@
+TaelinArena.Game.get_thing_by_pid: 
+  TaelinArena.Game.PlayerId ->
+  TaelinArena.Game.Game ->
+  Maybe(TaelinArena.Game.Thing)
+
+  (pid) (gm)
+  gm<() Maybe(TaelinArena.Game.Thing)> | (gm.stage)
+  List.seek<TaelinArena.Game.Thing>
+  |TaelinArena.Game.get_thing_by_pid.cond(pid);
+  |gm.stage;;

--- a/TaelinArena.Game.map_stage.fmc
+++ b/TaelinArena.Game.map_stage.fmc
@@ -1,0 +1,11 @@
+TaelinArena.Game.map_stage: 
+  (TaelinArena.Game.Thing -> TaelinArena.Game.Thing) ->
+  TaelinArena.Game.Game -> 
+  TaelinArena.Game.Game
+
+  (fn) (gm)
+  gm<() TaelinArena.Game.Game> | (gm.stage)
+  let new_stage = List.map<TaelinArena.Game.Thing><TaelinArena.Game.Thing>
+  |fn;
+  |gm.stage;
+  TaelinArena.Game.Game.new(new_stage);

--- a/TaelinArena.Game.with_thing.effect.fmc
+++ b/TaelinArena.Game.with_thing.effect.fmc
@@ -1,0 +1,12 @@
+TaelinArena.Game.with_thing.effect: 
+  TaelinArena.Game.PlayerId ->
+  (TaelinArena.Game.Thing -> TaelinArena.Game.Thing) ->
+  TaelinArena.Game.Thing    -> 
+  TaelinArena.Game.Thing
+  
+  (pid) (fn) (thi)
+  let thi.pid = TaelinArena.Game.get_thing_pid(thi)
+  F64.eql(pid)(thi.pid)<() TaelinArena.Game.Thing>
+  | fn(thi);
+  | thi;
+  

--- a/TaelinArena.Game.with_thing.fmc
+++ b/TaelinArena.Game.with_thing.fmc
@@ -1,11 +1,15 @@
 // Modifies the object with given id
 TaelinArena.Game.with_thing:
   TaelinArena.Game.PlayerId ->
-  TaelinArena.Game.Thing    -> 
+  (TaelinArena.Game.Thing -> TaelinArena.Game.Thing) -> 
   TaelinArena.Game.Game     -> 
   TaelinArena.Game.Game 
   
-  TaelinArena.Game.with_thing
+  (pid) (fn) (gm)
+  TaelinArena.Game.map_stage
+  |TaelinArena.Game.with_thing.effect(pid)(fn);
+  |gm;
+  
 // with_thing(pid:PlayerId, fn: Thing -> Thing, gm:Game) : Game
 //   let effect = (thi) =>
 //     case thi |thing

--- a/TaelinArena.Game.with_thing.fmc
+++ b/TaelinArena.Game.with_thing.fmc
@@ -1,0 +1,16 @@
+// Modifies the object with given id
+TaelinArena.Game.with_thing:
+  TaelinArena.Game.PlayerId ->
+  TaelinArena.Game.Thing    -> 
+  TaelinArena.Game.Game     -> 
+  TaelinArena.Game.Game 
+  
+  TaelinArena.Game.with_thing
+// with_thing(pid:PlayerId, fn: Thing -> Thing, gm:Game) : Game
+//   let effect = (thi) =>
+//     case thi |thing
+//     case number_equal(thi.pid, pid) as e
+//     with thi : Thing
+//     | true  => fn(thi)
+//     | false => thi
+//   map_stage(effect, gm)


### PR DESCRIPTION
 Related to [TaelinArena#165](https://github.com/moonad/TaelinArena/issues/165)
 
 Added:
-  `TaelinArena.Game.get_thing_by_pid`
-  `TaelinArena.Game.get_position_by_pid`
-  `TaelinArena.Game.map_stage`
-  `TaelinArena.Game.with_thing`
- `List.seek: <A: Type> -> (A -> Bool) -> List(A) -> Maybe(A)`:  seeks the first ocurrence that matches a condition (same as Formality's `List.find`)