### PR TITLE
Update fmc-type-check.yml

### DIFF
--- a/.github/workflows/fmc-type-check.yml
+++ b/.github/workflows/fmc-type-check.yml
@@ -21,9 +21,9 @@ jobs:
 
     # Install dependency
     - name: Install formality-core
-      run: npm i t-check-test # TODO: update to formality-core
+      run: npm i formality-core
     
     - name: Type check --github
       id: check_type_github
-      run: node node_modules/t-check-test/bin/fmc.js --github  # TODO: update to formality-core
+      run: node node_modules/formality-core/bin/fmc.js --github
           


### PR DESCRIPTION
Updates the Github Action to use `formality-core` when checking the types. Until now, we were using my personal package forked from Formality-Core.