### PR TITLE
adds Functor & VerifiedFunctor

### DIFF
--- a/Either.fm
+++ b/Either.fm
@@ -8,4 +8,32 @@ Either.bind<A: Type, B: Type, C: Type>(e: Either(A,B), f: B -> Either(A,C)): Eit
   | Either.left<A><C>(e.value);
   | f(e.value);
 
+// Either(A) functor
+// =================
+Either.functor<A: Type>: Functor(Either(A))
+  Functor.new<Either(A)>(Either.map<A>)
 
+Either.functor.verified<A: Type>: VerifiedFunctor(Either(A), Either.functor<A>)
+  VerifiedFunctor.new<Either(A), Either.functor<A>>(Either.map.id<A>, Either.map.comp<A>)
+
+Either.map<A: Type, B: Type, C: Type>(f: B -> C, e: Either(A, B)): Either(A, C)
+  case e:
+  | Either.left<A, C>(e.value);
+  | Either.right<A, C>(f(e.value));
+
+Either.map.id<A: Type, B: Type>(e: Either(A, B)): Equal(Either(A, B), Either.map<A, B, B>(Function.id<B>, e), e)
+  case e:
+  | _;
+  | _;
+  : Equal(_, Either.map<A,B,B>(Function.id<>, e.self), e.self);
+
+Either.map.comp<A: Type, B: Type, C: Type, D: Type>(e: Either(A, B), g: (C -> D), h: (B -> C))
+  : Equal(Either(A, D),
+          Either.map<A, B, D>(Function.comp<B, C, D>(g, h), e),
+          Function.comp<Either(A, B), Either(A, C), Either(A, D)>(Either.map<A, C, D>(g), Either.map<A, B, C>(h), e))
+  case e:
+  | _;
+  | _;
+  : Equal(_,
+          Either.map<,,>(Function.comp<,,>(g, h), e.self),
+          Function.comp<,,>(Either.map<,,>(g), Either.map<,,>(h))(e.self));

--- a/Function.fm
+++ b/Function.fm
@@ -6,17 +6,21 @@ Function(A: Type, B: A -> Type): Type
 Function.call<A: Type, B: Type>(x: A, f: A -> B): B
   f(x)
 
-// Dependent function composition.
-Function.comp<A:Type, B:Type, C:B->Type>(g:(b:B)->C(b), f:A -> B, x:A): C(f(x))
+// Function composition.
+Function.comp<A: Type, B: Type, C: Type>(g: B -> C, f: A -> B, x: A): C
   g(f(x))
 
 // Given a `x`, returns a function that receives an `y` and returns `x`.
-Function.const<A: Type>(x: A, y: A): A
+Function.const<A: Type, B: Type>(x: A, y: B): A
   x
 
 // Converts a function that receives a pair into a function of 2 arguments.
 Function.curry<A: Type, B: Type, C: Type>(f: Pair(A, B) -> C, x: A, y: B): C
   f(Pair.new<A><B>(x, y))
+
+// Dependent function composition.
+Function.dcomp<A:Type, B:Type, C:B->Type>(g:(b:B)->C(b), f:A -> B, x:A): C(f(x))
+  g(f(x))
 
 // Flips the two first arguments of a function.
 Function.flip<A: Type, B: Type, C: Type>(f: A -> B -> C, y: B, x: A): C

--- a/Functor.fm
+++ b/Functor.fm
@@ -25,4 +25,3 @@ T VerifiedFunctor<F: Type -> Type, f: Functor(F)>
             Functor.map<F>(f)<A, C>(Function.comp<A, B, C>(g, h), fa),
             Function.comp<F(A), F(B), F(C)>(Functor.map<F>(f)<B, C>(g), Functor.map<F>(f)<A, B>(h))(fa))
   );
-

--- a/Functor.fm
+++ b/Functor.fm
@@ -1,24 +1,7 @@
-// Functor where
-//   map :: (a -> b) -> f a -> f b
-// with map satisfying the laws
-//   map id == id
-//   map (f . g) == map f . map g
 T Functor<F: Type -> Type>
 | new(
-  map
-    : <A: Type, B: Type> ->
-      (A -> B) -> F(A) -> F(B)
-  )<
-  id
-    : <A: Type> ->
-      (fa: F(A)) -> Equal(F(A), map<A, A>(Function.id<A>, fa), Function.id<F(A)>(fa)),
-  comp
-    : <A: Type, B: Type, C: Type> ->
-      (fa: F(A)) -> (g: B -> C) -> (h: A -> B) ->
-      Equal(F(C),
-            map<A, C>(Function.comp<A, B, C>(g, h), fa),
-            Function.comp<F(A), F(B), F(C)>(map<B, C>(g), map<A, B>(h))(fa))
-  >;
+  map: <A: Type, B: Type> -> (A -> B) -> F(A) -> F(B)
+  );
 
 Functor.map<F: Type -> Type>(f: Functor(F)): <A: Type, B: Type> -> (A -> B) -> F(A) -> F(B)
   case f:
@@ -27,3 +10,19 @@ Functor.map<F: Type -> Type>(f: Functor(F)): <A: Type, B: Type> -> (A -> B) -> F
 Functor.const<F: Type -> Type>(f: Functor(F)): <A: Type, B: Type> -> A -> F(B) -> F(A)
   <A, B> (a)
   Functor.map<>(f)<,>(Function.const<,>(a))
+
+// VerifiedFunctor is a Functor
+// with map satisfying the functor laws
+//   map id == id
+//   map (f . g) == map f . map g
+T VerifiedFunctor<F: Type -> Type, f: Functor(F)>
+| new(
+  id: <A: Type> ->
+      (fa: F(A)) -> Equal(F(A), Functor.map<F>(f)<A, A>(Function.id<A>, fa), Function.id<F(A)>(fa)),
+  comp: <A: Type, B: Type, C: Type> ->
+      (fa: F(A)) -> (g: B -> C) -> (h: A -> B) ->
+      Equal(F(C),
+            Functor.map<F>(f)<A, C>(Function.comp<A, B, C>(g, h), fa),
+            Function.comp<F(A), F(B), F(C)>(Functor.map<F>(f)<B, C>(g), Functor.map<F>(f)<A, B>(h))(fa))
+  );
+

--- a/Functor.fm
+++ b/Functor.fm
@@ -1,0 +1,29 @@
+// Functor where
+//   map :: (a -> b) -> f a -> f b
+// with map satisfying the laws
+//   map id == id
+//   map (f . g) == map f . map g
+T Functor<F: Type -> Type>
+| new(
+  map
+    : <A: Type, B: Type> ->
+      (A -> B) -> F(A) -> F(B)
+  )<
+  id
+    : <A: Type> ->
+      (fa: F(A)) -> Equal(F(A), map<A, A>(Function.id<A>, fa), Function.id<F(A)>(fa)),
+  comp
+    : <A: Type, B: Type, C: Type> ->
+      (fa: F(A)) -> (g: B -> C) -> (h: A -> B) ->
+      Equal(F(C),
+            map<A, C>(Function.comp<A, B, C>(g, h), fa),
+            Function.comp<F(A), F(B), F(C)>(map<B, C>(g), map<A, B>(h))(fa))
+  >;
+
+Functor.map<F: Type -> Type>(f: Functor(F)): <A: Type, B: Type> -> (A -> B) -> F(A) -> F(B)
+  case f:
+  | f.map;
+
+Functor.const<F: Type -> Type>(f: Functor(F)): <A: Type, B: Type> -> A -> F(B) -> F(A)
+  <A, B> (a)
+  Functor.map<>(f)<,>(Function.const<,>(a))

--- a/List.fm
+++ b/List.fm
@@ -147,6 +147,19 @@ List.subsequences.go<A: Type>(xs: List(A)): List(List(A))
     | List.pure<>(xs.head);
     | List.foldr<,>(List.nil<>,f,List.subsequences.go<>(xs.tail));;
 
+// List transformation proofs
+// ==========================
+
+// Proof that List.cons(f(x)) & List.map(f, xs) commute
+List.commute_cons_map<A: Type, B: Type>(a :A, ls: List(A), f: A -> B)
+  : Equal(List(B),
+          List.cons<B>(f(a), List.map<A, B>(f, ls)),
+          List.map<A, B>(f, List.cons<A>(a, ls)))
+  case ls:
+  | _;
+  | _;
+  : Equal(_, List.cons<>(f(a), List.map<,>(f, ls.self)), List.map<,>(f, List.cons<>(a, ls.self)));
+
 // Reducing Lists
 // ==============
 
@@ -235,9 +248,45 @@ List.product.go(xs: List(Nat), n: Nat) : Nat
 List.show<A: Type>(f: A -> String, xs: List(A)): String
   String.flatten(["[",String.intercalate(",", List.map<,>(f,xs)),"]"])
 
+// List functor
+// ============
+
+// The functor instance for list
+List.functor: Functor(List)
+  Functor.new<List>(List.map)
+
+// Proof that List.functor conforms to the functor laws
+List.functor.verified: VerifiedFunctor(List, List.functor)
+  VerifiedFunctor.new<List, List.functor>(List.map.id, List.map.comp)
+
+List.map.id<A: Type>(ls: List(A)): Equal(List(A), List.map<A, A>(Function.id<A>, ls), ls)
+  case ls:
+  | Equal.to<_, List.map<,>(Function.id<>, List.nil<>)>;
+  | let tail_eq = List.map.id<>(ls.tail)
+    Equal.apply<_, _,
+                List.map<,>(Function.id<>, ls.tail),
+                ls.tail,
+                List.cons<>(ls.head)>(tail_eq);
+  : Equal(_, List.map<,>(Function.id<>, ls.self), ls.self);
+
+List.map.comp<A: Type, B: Type, C: Type>(ls: List(A), g: (B -> C), h: (A -> B))
+  : Equal(List(C),
+          List.map<A, C>(Function.comp<A, B, C>(g, h), ls),
+          Function.comp<List(A), List(B), List(C)>(List.map<B, C>(g), List.map<A, B>(h))(ls))
+  case ls:
+  | Equal.to<_, List.map<,>(Function.comp<,,>(g, h), List.nil<>)>;
+  | let tail_eq = List.map.comp<,,>(ls.tail, g, h)
+    Equal.apply<_, _,
+                List.map<,>(Function.comp<,,>(g, h), ls.tail),
+                Function.comp<,,>(List.map<,>(g), List.map<,>(h), ls.tail), List.cons<>(Function.comp<,,>(g, h, ls.head))>(tail_eq);
+  : Equal(_, List.map<,>(Function.comp<,,>(g, h), ls.self), Function.comp<,,>(List.map<,>(g), List.map<,>(h))(ls.self));
 
 // List monad
 // ==========
+
+// The monad instance for list
+List.monad: Monad(List)
+  Monad.new<List>(List.bind, List.pure)
 
 // A list with only one element.
 List.pure<A : Type>(x : A) : List(A)

--- a/Maybe.fm
+++ b/Maybe.fm
@@ -32,9 +32,12 @@ Maybe.map<A: Type, B: Type>(f: A -> B, m: Maybe(A)): Maybe(B)
 
 // Maybe functor
 // =============
+
+// The functor instance for maybe
 Maybe.functor: Functor(Maybe)
   Functor.new<Maybe>(Maybe.map)
 
+// Proof that Maybe.functor conforms to the functor laws
 Maybe.functor.verified: VerifiedFunctor(Maybe, Maybe.functor)
   VerifiedFunctor.new<Maybe, Maybe.functor>(Maybe.map.id, Maybe.map.comp)
 

--- a/Maybe.fm
+++ b/Maybe.fm
@@ -30,9 +30,13 @@ Maybe.map<A: Type, B: Type>(f: A -> B, m: Maybe(A)): Maybe(B)
   | Maybe.none<B>;
   | Maybe.some<B>(f(m.value));
 
-// the functor instance for Maybe
+// Maybe functor
+// =============
 Maybe.functor: Functor(Maybe)
-  Functor.new<Maybe>(Maybe.map)<Maybe.map.id, Maybe.map.comp>
+  Functor.new<Maybe>(Maybe.map)
+
+Maybe.functor.verified: VerifiedFunctor(Maybe, Maybe.functor)
+  VerifiedFunctor.new<Maybe, Maybe.functor>(Maybe.map.id, Maybe.map.comp)
 
 Maybe.map.id<A: Type>(ma: Maybe(A)): Equal(Maybe(A), Maybe.map<A, A>(Function.id<A>, ma), ma)
   case ma:

--- a/Maybe.fm
+++ b/Maybe.fm
@@ -29,3 +29,24 @@ Maybe.map<A: Type, B: Type>(f: A -> B, m: Maybe(A)): Maybe(B)
   case m:
   | Maybe.none<B>;
   | Maybe.some<B>(f(m.value));
+
+// the functor instance for Maybe
+Maybe.functor: Functor(Maybe)
+  Functor.new<Maybe>(Maybe.map)<Maybe.map.id, Maybe.map.comp>
+
+Maybe.map.id<A: Type>(ma: Maybe(A)): Equal(Maybe(A), Maybe.map<A, A>(Function.id<A>, ma), ma)
+  case ma:
+  | _;
+  | _;
+  : Equal(_, Maybe.map<,>(Function.id<>, ma.self), ma.self);
+
+Maybe.map.comp<A: Type, B: Type, C: Type>(ma: Maybe(A), g: (B -> C), h: (A -> B))
+  : Equal(Maybe(C),
+          Maybe.map<A, C>(Function.comp<A, B, C>(g, h), ma),
+          Function.comp<Maybe(A), Maybe(B), Maybe(C)>(Maybe.map<B, C>(g), Maybe.map<A, B>(h))(ma))
+  case ma:
+  | _;
+  | _;
+  : Equal(_,
+          Maybe.map<,>(Function.comp<,,>(g, h), ma.self),
+          Function.comp<,,>(Maybe.map<,>(g), Maybe.map<,>(h))(ma.self));

--- a/Pair.fm
+++ b/Pair.fm
@@ -8,3 +8,30 @@ Pair.fst<A: Type, B: Type>(pair: Pair(A)(B)): A
 Pair.snd<A: Type, B: Type>(pair: Pair(A)(B)): B
   case pair:
   | pair.snd;
+
+// Pair(A) functor
+// =================
+Pair.functor<A: Type>: Functor(Pair(A))
+  Functor.new<Pair(A)>(Pair.map<A>)
+
+Pair.functor.verified<A: Type>: VerifiedFunctor(Pair(A), Pair.functor<A>)
+  VerifiedFunctor.new<Pair(A), Pair.functor<A>>(Pair.map.id<A>, Pair.map.comp<A>)
+
+Pair.map<A: Type, B: Type, C: Type>(f: B -> C, p: Pair(A, B)): Pair(A, C)
+  case p:
+  | Pair.new<A, C>(p.fst, f(p.snd));
+
+Pair.map.id<A: Type, B: Type>(p: Pair(A, B)): Equal(Pair(A, B), Pair.map<A, B, B>(Function.id<B>, p), p)
+  case p:
+  | _;
+  : Equal(_, Pair.map<A,B,B>(Function.id<>, p.self), p.self);
+
+Pair.map.comp<A: Type, B: Type, C: Type, D: Type>(e: Pair(A, B), g: (C -> D), h: (B -> C))
+  : Equal(Pair(A, D),
+          Pair.map<A, B, D>(Function.comp<B, C, D>(g, h), e),
+          Function.comp<Pair(A, B), Pair(A, C), Pair(A, D)>(Pair.map<A, C, D>(g), Pair.map<A, B, C>(h), e))
+  case e:
+  | _;
+  : Equal(_,
+          Pair.map<,,>(Function.comp<,,>(g, h), e.self),
+          Function.comp<,,>(Pair.map<,,>(g), Pair.map<,,>(h))(e.self));


### PR DESCRIPTION
`VerifiedFunctor` requires proofs that `map` conforms to the `Functor` laws

adds `Functor` and `VerifiedFunctor` instances for 
  - `Maybe`
  - `List`
  - `Either(A)`
  - `Pair(A)`